### PR TITLE
Hash password with sha256

### DIFF
--- a/src/hooks/ykfde
+++ b/src/hooks/ykfde
@@ -36,6 +36,10 @@ ykfde_challenge_response() {
       printf "   Enter password: "; if [ $DBG ]; then read _pw; else read -s _pw; fi
       done
       [ $DBG ] || echo # if /NOT/ DBG, we need to output \n here.
+      # Hash provided password with sha256
+      while [ -n "$_pw" ]; do
+      _pw=$(printf %s "$_pw" | sha256sum | awk '{print $1}')
+      done
       YKFDE_CHALLENGE="$_pw"
     fi
       [ $DBG ] && printf "   (used time:$_usedtime, timeout:$_yubikey_timeout) ykinfo -$YKFDE_CHALLENGE_SLOT \"$YKFDE_CHALLENGE\": "


### PR DESCRIPTION
Using password as challenge can have some drawbacks.
1. Password can be very weak like "aaa"
2. Password can be longer than 64 characters which is max for yubikey challenge which result in breakage.

As solution we can hash the password with sha256 which give us 64 characters (maximum) length challenge for any user provided password.

In result we have 104 (64+40) characters long LUKS passphrase